### PR TITLE
LADX: updates to minimal accessibility fix pr

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -363,18 +363,16 @@ class LinksAwakeningWorld(World):
 
         # Set up state
         partial_all_state = CollectionState(self.multiworld)
-        # Collect every item from the item pool and every pre-fill item like MultiWorld.get_all_state, but don't sweep.
+        # Collect every item from the item pool and every pre-fill item like MultiWorld.get_all_state, except not our own pre-fill items.
         for item in self.multiworld.itempool:
             partial_all_state.collect(item, prevent_sweep=True)
         for player in self.multiworld.player_ids:
+            if player == self.player:
+                # Don't collect the items we're about to place.
+                continue
             subworld = self.multiworld.worlds[player]
             for item in subworld.get_pre_fill_items():
                 partial_all_state.collect(item, prevent_sweep=True)
-        # get_all_state would normally sweep here, but we need to remove our dungeon items first.
-        
-        # Remove dungeon items we are about to put in from the state so that we don't double count
-        for item in all_dungeon_items_to_fill:
-            partial_all_state.remove(item)
 
         # Sweep to pick up already placed items that are reachable with everything but the dungeon items.
         partial_all_state.sweep_for_advancements()

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -305,8 +305,6 @@ class LinksAwakeningWorld(World):
 
         # Set up filter rules
 
-        # The list of items we will pass to fill_restrictive, contains at first the items that go to all dungeons
-        all_dungeon_items_to_fill = list(self.prefill_own_dungeons)
         # set containing the list of all possible dungeon locations for the player
         all_dungeon_locs = set()
         
@@ -316,9 +314,6 @@ class LinksAwakeningWorld(World):
             locs = set(loc for loc in self.dungeon_locations_by_dungeon[dungeon_index] if not loc.item)
             for item in self.prefill_original_dungeon[dungeon_index]:
                 allowed_locations_by_item[item] = locs
-
-            # put the items for this dungeon in the list to fill
-            all_dungeon_items_to_fill.extend(self.prefill_original_dungeon[dungeon_index])
 
             # ...and gather the list of all dungeon locations
             all_dungeon_locs |= locs
@@ -359,6 +354,7 @@ class LinksAwakeningWorld(World):
             if allowed_locations_by_item[item] is all_dungeon_locs:
                 i += 3
             return i
+        all_dungeon_items_to_fill = self.get_pre_fill_items()
         all_dungeon_items_to_fill.sort(key=priority)
 
         # Set up state


### PR DESCRIPTION
Updates for this pr: https://github.com/ArchipelagoMW/Archipelago/pull/4281

Based on Mysteryem's comment https://github.com/ArchipelagoMW/Archipelago/pull/4281#issuecomment-2523988170

Nothing actually changes here, its just cleanup based on the fact that our `all_dungeon_items_to_fill` list is simply our pre fill items.

So instead of removing those items from our partial all state we can just skip our own pre fills, and instead of building `all_dungeon_items_to_fill` from our `own_dungeon` and `original_dungeon` prefills, we can just use `get_all_pre_fill_items`

I did some test generations as well

I can submit this as its own PR to the main repo if you'd prefer, this just seemed simpler